### PR TITLE
Dramatically simplify features/support/world

### DIFF
--- a/features/support/assemblies/database.js
+++ b/features/support/assemblies/database.js
@@ -6,6 +6,8 @@ module.exports = class DatabaseAssembly {
     await this._databaseTodoList.start(true)
   }
 
+  async stop() {}
+
   async contextTodoList() {
     return this._databaseTodoList
   }

--- a/features/support/assemblies/dom-http-memory.js
+++ b/features/support/assemblies/dom-http-memory.js
@@ -12,6 +12,8 @@ module.exports = class DomHttpMemoryAssembly {
     this.webApp = new WebApp({ todoList: this._memoryTodoList, serveClient: false })
   }
 
+  async stop() {}
+
   async contextTodoList() {
     return this._memoryTodoList
   }

--- a/features/support/assemblies/dom-memory.js
+++ b/features/support/assemblies/dom-memory.js
@@ -9,6 +9,8 @@ module.exports = class DomMemoryAssembly {
     this._memoryTodoList = new MemoryTodoList()
   }
 
+  async stop() {}
+
   async contextTodoList() {
     return this._memoryTodoList
   }

--- a/features/support/assemblies/memory.js
+++ b/features/support/assemblies/memory.js
@@ -5,6 +5,8 @@ module.exports = class MemoryAssembly {
     this._memoryTodoList = new MemoryTodoList()
   }
 
+  async stop() {}
+
   async contextTodoList() {
     return this._memoryTodoList
   }


### PR DESCRIPTION
Now that assemblies have been moved into their own modules, this removes all the clever stuff from `features/support/world.js` making the pattern of steps using assemblies much easier to follow.

Assemblies are now expected to implement `async start()` and `async stop()` even if they do nothing.